### PR TITLE
Fix unprefixed replacement of UIKit method

### DIFF
--- a/DBDebugToolkit/Classes/Categories/UIView+Snapshot.h
+++ b/DBDebugToolkit/Classes/Categories/UIView+Snapshot.h
@@ -28,6 +28,6 @@
 /**
  Creates and returns an image containing 
  */
-- (UIImage *)snapshot;
+- (UIImage *)db_snapshot;
 
 @end

--- a/DBDebugToolkit/Classes/Categories/UIView+Snapshot.m
+++ b/DBDebugToolkit/Classes/Categories/UIView+Snapshot.m
@@ -24,7 +24,7 @@
 
 @implementation UIView (Snapshot)
 
-- (UIImage *)snapshot {
+- (UIImage *)db_snapshot {
     UIGraphicsBeginImageContextWithOptions(self.bounds.size, NO, [UIScreen mainScreen].scale);
     [self drawViewHierarchyInRect:self.bounds afterScreenUpdates:NO];
     UIImage *image = UIGraphicsGetImageFromCurrentImageContext();

--- a/DBDebugToolkit/Classes/CrashReports/DBCrashReportsToolkit.m
+++ b/DBDebugToolkit/Classes/CrashReports/DBCrashReportsToolkit.m
@@ -229,7 +229,7 @@ static void handleSIGPIPESignal(int sig) {
                callStackSymbols:(NSArray<NSString *> *)callStackSymbols
                            date:(NSDate *)date {
     BOOL isMainThread = [NSThread isMainThread];
-    UIImage *screenshot = isMainThread ? [[UIApplication sharedApplication].keyWindow snapshot] : nil;
+    UIImage *screenshot = isMainThread ? [[UIApplication sharedApplication].keyWindow db_snapshot] : nil;
     [self saveCrashReportWithName:name
                            reason:reason
                          userInfo:userInfo


### PR DESCRIPTION
This fixes the warning
```
objc[15471]: REPLACED: -[UIView snapshot]  by category Snapshot  (IMP was 0x114d445aa (/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/UIKitCore.framework/UIKitCore), now 0x10120d431 (<my-app>.app/Frameworks/DBDebugToolkit.framework/DBDebugToolkit))
```

when environment variable `OBJC_PRINT_REPLACED_METHODS=YES` is set.
Basically the method `snapshot` already exists on `UIView` and is shadowed by the implementation
of `DBDebugToolkit`. You should probably consider prefixing all other category methods too.