### PR TITLE
Create the ability to provide view controller

### DIFF
--- a/DBDebugToolkit/Classes/DBDebugToolkit.h
+++ b/DBDebugToolkit/Classes/DBDebugToolkit.h
@@ -21,6 +21,7 @@
 // THE SOFTWARE.
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 #import "DBDebugToolkitTrigger.h"
 #import "DBCustomAction.h"
 #import "DBCustomVariable.h"
@@ -29,6 +30,11 @@
  `DBDebugToolkit` provides the interface that can be used to setup and customize the debugging tools.
  */
 @interface DBDebugToolkit : NSObject
+
+/**
+ Provides `UINavigationController` to custom showing.
+ */
++ (UINavigationController *)viewController;
 
 ///------------
 /// @name Setup

--- a/DBDebugToolkit/Classes/DBDebugToolkit.m
+++ b/DBDebugToolkit/Classes/DBDebugToolkit.m
@@ -60,6 +60,11 @@ static NSString *const DBDebugToolkitObserverPresentationControllerPropertyKeyPa
 
 @implementation DBDebugToolkit
 
++ (UINavigationController *)viewController {
+    DBDebugToolkit *toolkit = [DBDebugToolkit sharedInstance];
+    return [[UINavigationController alloc] initWithRootViewController:toolkit.menuViewController];
+}
+
 #pragma mark - Setup
 
 + (void)setup {


### PR DESCRIPTION
I'm created the ability to provide `mainViewController` as UINavigationController.
I needed to implement the ability to use `mainViewController` to custom shows.
Now, we can use it like this:
`let navigationController = DBDebugToolkit.mainViewController()`
