### PR TITLE
Fix: Don't leak an NSURLSession for every request when network logging is enabled

### DIFF
--- a/DBDebugToolkit/Classes/Network/URLProtocol/DBURLProtocol.m
+++ b/DBDebugToolkit/Classes/Network/URLProtocol/DBURLProtocol.m
@@ -90,6 +90,7 @@ static NSString *const DBURLProtocolHandledKey = @"DBURLProtocolHandled";
         }
         
         [self.client URLProtocolDidFinishLoading:self];
+        [self.urlSession finishTasksAndInvalidate];
     }] resume];
 }
 


### PR DESCRIPTION
The [documentation for NSURLSession](https://developer.apple.com/documentation/foundation/nsurlsession) is quite clear:

> The session object keeps a strong reference to the delegate until your app exits or explicitly invalidates the session. If you don’t invalidate the session, your app leaks memory until the app terminates.

DBURLProtocol stores a NSURLSession as a property, and is also the delegate of that session, so there's a strong reference cycle for each object. And the way the NSURLProtocol system works means that a new DBURLProtocol object is created for _every_ network request.

Consequently, DBDebugToolkit is leaking an entire new NSURLSession stack for _every_ network request when network logging is enabled. Calling `finishTasksAndInvalidate` once the request is completed fixes this.

Aside:
Even without this memory leak, I have major concerns about DBDebugToolkit's network logging implementation. Creating a _new_ NSURLSession for _every request_ is very inefficient. It's also quite disruptive: it means that the NSURLSessionConfiguration parameters a developer sets in their app aren't _actually_ being applied when this network logging is enabled.