### PR TITLE
Fix NSURLSession redirection handling broken #22

### DIFF
--- a/DBDebugToolkit/Classes/Network/URLProtocol/DBURLProtocol.m
+++ b/DBDebugToolkit/Classes/Network/URLProtocol/DBURLProtocol.m
@@ -27,7 +27,7 @@
 
 static NSString *const DBURLProtocolHandledKey = @"DBURLProtocolHandled";
 
-@interface DBURLProtocol () <NSURLSessionDelegate>
+@interface DBURLProtocol () <NSURLSessionDelegate, NSURLSessionTaskDelegate>
 
 @property (nonatomic, strong) NSURLSession *urlSession;
 
@@ -108,6 +108,12 @@ static NSString *const DBURLProtocolHandledKey = @"DBURLProtocolHandled";
     DBAuthenticationChallengeSender *challengeSender = [DBAuthenticationChallengeSender authenticationChallengeSenderWithSessionCompletionHandler:completionHandler];
     NSURLAuthenticationChallenge *modifiedChallenge = [[NSURLAuthenticationChallenge alloc] initWithAuthenticationChallenge:challenge sender:challengeSender];
     [self.client URLProtocol:self didReceiveAuthenticationChallenge:modifiedChallenge];
+}
+
+#pragma mark - NSURLSessionTaskDelegate
+
+- (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task willPerformHTTPRedirection:(NSHTTPURLResponse *)response newRequest:(NSURLRequest *)request completionHandler:(void (^)(NSURLRequest *))completionHandler {
+    [self.client URLProtocol:self wasRedirectedToRequest:request redirectResponse:response];
 }
 
 @end


### PR DESCRIPTION
Whenever an app using `DBDebugToolkit` uses a `NSURLSession` to handle requests, `DBDebugToolkit` creates another `NSURLSession` instance and uses `DBURLProtocol` as the `NSURLSessionDelegate`. Because of this, the original delegate is ignored unless the `NSURLProtocol.client` is notified. This was already implemented for authentication challenges, now I added redirect support.

With this pull request the sample code provided by @TheDom in https://github.com/dbukowski/DBDebugToolkit/issues/22#issuecomment-445041989 works too.

I suspect other bugs related to `NSURLSessionTasks` – for example caching – have a similar cause.
