### PR TITLE
Use NSURLSessionConfiguration.ephemeralSessionConfiguration internally in own NSURLSession when app tries to use this configuration for their NSURLSession

### DIFF
--- a/DBDebugToolkit/Classes/Network/URLProtocol/DBURLProtocol.m
+++ b/DBDebugToolkit/Classes/Network/URLProtocol/DBURLProtocol.m
@@ -35,6 +35,10 @@ static NSString *const DBURLProtocolHandledKey = @"DBURLProtocolHandled";
 
 @implementation DBURLProtocol
 
++ (NSURLSessionConfiguration *)sessionConfiguration {
+    return NSURLSessionConfiguration.defaultSessionConfiguration;
+}
+
 + (BOOL)canInitWithTask:(NSURLSessionTask *)task {
     NSURLRequest *request = task.currentRequest;
     return request == nil ? NO : [self canInitWithRequest:request];
@@ -64,11 +68,11 @@ static NSString *const DBURLProtocolHandledKey = @"DBURLProtocolHandled";
     
     if (!self.urlSession) {
         if ([[[UIDevice currentDevice] systemVersion] compare:@"10.0" options:NSNumericSearch] != NSOrderedAscending) {
-            self.urlSession = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]
+            self.urlSession = [NSURLSession sessionWithConfiguration:[[self class] sessionConfiguration]
                                                             delegate:self
                                                        delegateQueue:nil];
         } else {
-            self.urlSession = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]];
+            self.urlSession = [NSURLSession sessionWithConfiguration:[[self class] sessionConfiguration]];
         }
     }
     

--- a/DBDebugToolkit/Classes/Network/URLProtocol/NSURLSessionConfiguration+DBURLProtocol.m
+++ b/DBDebugToolkit/Classes/Network/URLProtocol/NSURLSessionConfiguration+DBURLProtocol.m
@@ -24,6 +24,19 @@
 #import "DBURLProtocol.h"
 #import "NSObject+DBDebugToolkit.h"
 
+/**
+`DBEphemeralURLProtocol` is a `DBURLProtocol` subclass for internal usage of `NSURLSession.ephemeralSessionConfiguration`
+*/
+@interface DBEphemeralURLProtocol : DBURLProtocol
+@end
+
+@implementation DBEphemeralURLProtocol
++ (NSURLSessionConfiguration *)sessionConfiguration {
+    return NSURLSessionConfiguration.ephemeralSessionConfiguration;
+}
+@end
+
+
 @implementation NSURLSessionConfiguration (DBURLProtocol)
 
 #pragma mark - Method Swizzling
@@ -49,7 +62,7 @@
 + (instancetype)db_ephemeralSessionConfiguration {
     NSURLSessionConfiguration *ephemeralSessionConfiguration = [self db_ephemeralSessionConfiguration];
     NSMutableArray *originalProtocols = [NSMutableArray arrayWithArray:ephemeralSessionConfiguration.protocolClasses];
-    [originalProtocols insertObject:[DBURLProtocol class] atIndex:0];
+    [originalProtocols insertObject:[DBEphemeralURLProtocol class] atIndex:0];
     ephemeralSessionConfiguration.protocolClasses = originalProtocols;
     return ephemeralSessionConfiguration;
 }


### PR DESCRIPTION
As mentioned in https://github.com/dbukowski/DBDebugToolkit/pull/40#issue-468136740 `DBDebugToolkit` ignores the `NSURLSessionConfiguration` specified by developers and creates its own. While this pull request doesn't solve the root problem, at least `.ephemeral` session configurations are now used when specified.