### PR TITLE
Fix `DBNetworkURLProtocolClass` Crash

### DIFF
--- a/DBDebugToolkit/Classes/Network/DBNetworkToolkit.m
+++ b/DBDebugToolkit/Classes/Network/DBNetworkToolkit.m
@@ -38,7 +38,7 @@ Class DBNetworkURLProtocolClass;
 
 #pragma mark - Initialization
 
-+ (void)initialize {
++ (void)load {
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         DBNetworkURLProtocolClass = [DBURLProtocol class];


### PR DESCRIPTION
Continuing [https://github.com/dbukowski/DBDebugToolkit/issues/56](https://github.com/dbukowski/DBDebugToolkit/issues/56) to fix the issue with following:
* Replace `initialize` with `load` in `DBNetworkToolkit.m`